### PR TITLE
Make matchesInAnyOrder with TypeMatchMode public

### DIFF
--- a/src/main/java/com/exasol/matcher/ResultSetStructureMatcher.java
+++ b/src/main/java/com/exasol/matcher/ResultSetStructureMatcher.java
@@ -468,7 +468,7 @@ public class ResultSetStructureMatcher extends TypeSafeMatcher<ResultSet> {
          * @param typeMatchMode mode for type matching
          * @return matcher the new matcher
          */
-        private Matcher<ResultSet> matchesInAnyOrder(final TypeMatchMode typeMatchMode) {
+        public Matcher<ResultSet> matchesInAnyOrder(final TypeMatchMode typeMatchMode) {
             this.requireSameOrder = false;
             this.typeMatchMode = typeMatchMode;
             return new ResultSetStructureMatcher(this);


### PR DESCRIPTION
Same as matches with and without TypeMatchMode are both public, also matchesInAnyOrder with and without TypeMatchMode are both public.